### PR TITLE
Local images and Card Holder Name box-shadow

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -335,6 +335,7 @@ body {
 
   &__name {
     font-size: 18px;
+    height: 18px;
     line-height: 1;
     white-space: nowrap;
     max-width: 100%;
@@ -343,6 +344,7 @@ body {
     text-transform: uppercase;
     @media screen and (max-width: 480px) {
       font-size: 16px;
+      height: 16px;
     }
   }
   &__nameItem {

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -17,13 +17,13 @@
       <div class="card-item__wrapper">
         <div class="card-item__top">
           <img
-            src="https://raw.githubusercontent.com/muhammederdem/credit-card-form/master/src/assets/images/chip.png"
+            src="@/assets/images/chip.png"
             class="card-item__chip"
           />
           <div class="card-item__type">
             <transition name="slide-fade-up">
               <img
-                :src="'https://raw.githubusercontent.com/muhammederdem/credit-card-form/master/src/assets/images/' + cardType + '.png'"
+                :src="getCardTypeImgUrl()"
                 v-if="cardType"
                 :key="cardType"
                 alt
@@ -66,7 +66,7 @@
                   >{{n}}</span>
                 </transition-group>
               </div>
-              <div class="card-item__name" v-else key="2">Ad Soyad</div>
+              <div class="card-item__name" v-else key="2"></div>
             </transition>
           </label>
           <div class="card-item__date" ref="cardDate">
@@ -104,7 +104,7 @@
         </div>
         <div class="card-item__type">
           <img
-            :src="'https://raw.githubusercontent.com/muhammederdem/credit-card-form/master/src/assets/images/' + cardType + '.png'"
+            :src="getCardTypeImgUrl()"
             v-if="cardType"
             class="card-item__typeImg"
           />
@@ -206,7 +206,7 @@ export default {
     currentCardBackground () {
       if (this.randomBackgrounds && !this.backgroundImage) { // TODO will be optimized
         let random = Math.floor(Math.random() * 25 + 1)
-        return `https://raw.githubusercontent.com/muhammederdem/credit-card-form/master/src/assets/images/${random}.jpeg`
+        return require(`@/assets/images/${random}.jpeg`)
       } else if (this.backgroundImage) {
         return this.backgroundImage
       } else {
@@ -237,6 +237,9 @@ export default {
       this.$nextTick(() => {
         this.changeFocus()
       })
+    },
+    getCardTypeImgUrl () {
+      return require(`@/assets/images/${this.cardType}.png`)
     }
   }
 }


### PR DESCRIPTION
The Card Holder name comes with a default value.  If you remove the value, then the box shadow doesn't size correctly.  I've set the height of the div to be the same as the font size.

The source code loads all images from Github currently.  In the event that those image paths on Github ever change, the code will break.  I've changed this so that images will now load from local paths.