### PR TITLE
Amex CVV on front of card

### DIFF
--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -695,3 +695,12 @@ body {
     }
   }
 }
+
+.card-item-cvv-amex {
+  color: #fff;
+  margin-top: -6%;
+  font-size: 27px;
+  font-weight: 500;
+  position: absolute;
+  left: 78%;
+}

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -32,6 +32,12 @@
             </transition>
           </div>
         </div>
+        <!-- CVV on front of card for Amex -->
+        <div  v-if="cardType === 'amex'">
+            <div class="card-item-cvv-amex">
+                <span v-for="(n, $index) in labels.cardCvv" :key="$index">*</span>
+            </div>
+        </div>
         <label :for="fields.cardNumber" class="card-item__number" :ref="fields.cardNumber">
           <template>
             <span v-for="(n, $index) in currentPlaceholder" :key="$index">
@@ -164,7 +170,7 @@ export default {
         } else {
           this.currentFocus = element.id
         }
-        this.isCardFlipped = element.id === this.fields.cardCvv
+        if (this.cardType !== 'amex') this.isCardFlipped = element.id === this.fields.cardCvv
       })
       element.addEventListener('blur', () => {
         this.isCardFlipped = !element.id === this.fields.cardCvv


### PR DESCRIPTION
I have added support for the CVV on the front of Amex cards. As seen in [this image](https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.cvvnumber.com%2F&psig=AOvVaw0xzLcitPN81y71AJTDyn2t&ust=1595703787229000&source=images&cd=vfe&ved=0CAIQjRxqFwoTCJjcw_3J5uoCFQAAAAAdAAAAABAD) the CVV for an Amex card is on the front of the card, not the back. This PR prevents the card from being flipped if the card is an `amex` type. It also places the CVV for the card just above and to the right of the main card number. As shown [here.](https://imgur.com/gallery/fA9VOr5)

This PR will close #6 .